### PR TITLE
Reworked addMetricsInfo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ stateOnClient = enabled
 ```
 Take note of the `restartSplunkd` setting. This should ALWAYS be '1' or 'true' for this app to ensure the restart mechanism works properly.
 
+## Example Configuration
+Below is an example of the configuration derived from a host in AWS.
+
+```
+[perfmon]
+_meta = os::"Microsoft Windows Server 2022 Datacenter" os_version::10.0.20348 ipv4::"10.#.#.#" ipv6::"fe80::####:####:###:####%26" entity_type::Windows_Host region::"us-east-1a" instance_id::"i-0###########" vpc_id::"vpc-#############" account_id::"5############" public_ip::"3.#.#.#.#"
+```
+Hosts outside of AWS will not derive fields after the `entity_type` field. `public_ip` will only be captured if a public IP is assigned to the AWS instance.
+
 ## Cleaning the meta
 In the event a host has changes made to it, we need a way to regenerate the meta configuration. The `cleanMeta.ps1` script is designed to remove the existing `_meta` configuration from a host. For example, if a Windows server is upgraded from Server 2016 to Server 2019, we need the `_meta` value to reflect that.
 

--- a/bin/addMetricsInfo.ps1
+++ b/bin/addMetricsInfo.ps1
@@ -6,7 +6,6 @@
 ## Variables used in the script
 $APPHOME = $SplunkHome + "\etc\apps\metrics_meta_settings"
 $INPUTCONF = $APPHOME + "\local\inputs.conf"
-$METRICSPARAM = "base"
 $CHECKPOINT = $SplunkHome + "\etc\metricsCheckpoint"
 $METAPATH = $SplunkHome + "\etc\restart_meta.txt"
 
@@ -17,49 +16,53 @@ exit
 
 ## Create the app directoy if it doesn't exist
 if (-not (Test-Path "$APPHOME")) {
-	New-Item "$APPHOME\local" -ItemType Directory | Out-Null
-	New-Item "$APPHOME\metadata" -ItemType Directory | Out-Null
-	echo '[]
+ New-Item "$APPHOME\local" -ItemType Directory | Out-Null
+ New-Item "$APPHOME\metadata" -ItemType Directory | Out-Null
+ Write-Output '[]
 access = read : [ * ], write : [ admin ]
-export = system' > "$APPHOME\metadata\local.meta"
+export = system' | Set-Content -Path "$APPHOME\metadata\local.meta"
 }
 
 ## Determine if the host is in AWS and capture AWS related dimensions
-if (Test-Path "C:\Windows\Amazon\Ec2ConfigService") {
-  $instance_id = Invoke-RestMethod -Uri http://169.254.169.254/latest/meta-data/instance-id
-  $account_id = (Invoke-RestMethod -Uri http://169.254.169.254/latest/meta-data/identity-credentials/ec2/info/).accountId
-  $region = Invoke-RestMethod -Uri http://169.254.169.254/latest/meta-data/placement/availability-zone
-  $cloud_dims = " region::$region instance_id::$instance_id account_id::$account_id"
+if (Test-Path "$env:ProgramFiles\Amazon\SSM") {
+ $instance_id = Invoke-RestMethod -Uri http://169.254.169.254/latest/meta-data/instance-id
+ $account_id = (Invoke-RestMethod -Uri http://169.254.169.254/latest/meta-data/identity-credentials/ec2/info/).accountId
+ $region = Invoke-RestMethod -Uri http://169.254.169.254/latest/meta-data/placement/availability-zone
+ $mac_address = Invoke-RestMethod -Uri http://169.254.169.254/latest/meta-data/mac
+ $vpc_id = Invoke-RestMethod http://169.254.169.254/latest/meta-data/network/interfaces/macs/$mac_address/vpc-id
+ $cloud_dims = $cloud_dims + " region::" + "`"" + $region  + "`""
+ $cloud_dims = $cloud_dims + " instance_id::" + "`"" + $instance_id  + "`""
+ $cloud_dims = $cloud_dims + " vpc_id::"  + "`"" + $vpc_id + "`""
+ $cloud_dims = $cloud_dims + " account_id::" + "`"" + $account_id  + "`""
+ try { $public_ip = Invoke-RestMethod http://169.254.169.254/latest/meta-data/public-ipv4
+	 } catch {
+ }
+ if (-not ([string]::IsNullOrEmpty($public_ip))) {
+	 $cloud_dims = $cloud_dims + " public_ipv4::" + "`"" + $public_ip + "`""
+ }
 }
-
-## List of inputs that will be added to the inputs.conf
-$m_base ="[perfmon]`r`n" `
-+ "disabled = 0"
 
 ## Capture the OS and IP details of the host
 $os_info = Get-CimInstance Win32_OperatingSystem | Select-Object Caption, Version
-$ip_info = Test-Connection -ComputerName $env:computername -count 1 | Select-Object IPV4Address
+$ipv4_info = Test-Connection -ComputerName $env:computername -count 1 | Select-Object IPV4Address
+$ipv6_info = Test-Connection -ComputerName $env:computername -count 1 | Select-Object IPV6Address
 
 ## Construct the dimensions into a single string together
 $dims = "os::" + "`"" + $os_info.Caption + "`""
 $dims = $dims + " os_version::" + $os_info.Version
-$dims = $dims + " ip::" + "`"" + $ip_info.IPV4Address.IPAddressToString + "`""
-$dims = $dims + ' entity_type::Windows'
+$dims = $dims + " ipv4::" + "`"" + $ipv4_info.IPV4Address.IPAddressToString + "`""
+if (-not ([string]::IsNullOrEmpty($ipv6_info))) {
+$dims = $dims + " ipv6::" + "`"" + $ipv6_info.IPV6Address.IPAddressToString + "`""
+}
+$dims = $dims + ' entity_type::Windows_Host'
 if (-not ([string]::IsNullOrEmpty($cloud_dims))) {
 $dims = $dims + $cloud_dims
 }
 
-## Create the inputs.conf in the app and populate it with the stanzas and dimensions
-$metrics = $METRICSPARAM -split ','
-echo '' > $INPUTCONF
-For ($i=0; $i -lt $metrics.Length; $i++) {
-  $m_name = "m_" + $metrics[$i]
-  Get-Variable -Name $m_name -ValueOnly -ErrorAction 'Ignore' >> $INPUTCONF
-  # Add dimensions
-  echo "_meta = $dims" >> $INPUTCONF
-  echo "`n" >> $INPUTCONF
-}
+## Create the inputs.conf in the app and populate it with a default configuration
+Write-Output "[perfmon]
+_meta = $dims" | Set-Content -Path "$INPUTCONF"
 
 ## Set up checkpoint value to ensure the script only runs once and create restart file
-echo '' > $CHECKPOINT
-echo '' > $METAPATH
+Write-Output "" | Set-Content -Path "$CHECKPOINT"
+Write-Output "" | Set-Content -Path "$METAPATH"

--- a/default/app.conf
+++ b/default/app.conf
@@ -9,4 +9,4 @@ is_visible = false
 is_manageable = false
 
 [launcher]
-version = 2.0.0
+version = 2.1.0


### PR DESCRIPTION
- Removed configurations in the script that are not utilized
- Changed `echo` actions to use `Write-Output`
- Changed AWS logic to use `SSM` directory for determining if host is in AWS
- Configured `region`, `instance_id`, `vpc_id`, `account_id`, and `public_ipv4` dimensions (if present) for AWS hosts
- Updated README with anonymized example output from script